### PR TITLE
Add roles_galaxy to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 venv/
 password_file
 .envrc
+roles_galaxy/


### PR DESCRIPTION
The idea behind roles_galaxy is that all roles installed by galaxy are there and can therefore be ignored